### PR TITLE
Rename rod's github links, from "master" to "main".

### DIFF
--- a/i18n/fr-FR/custom-launch.md
+++ b/i18n/fr-FR/custom-launch.md
@@ -105,15 +105,15 @@ Read the API doc for more info: [link](https://pkg.go.dev/github.com/go-rod/rod/
 
 ## Remotely manage the launcher :id=remotely-manage-the-launcher
 
-For production scraping system, usually, we will separate the scrapers and browsers into different clusters so that they can scale separately. Rod provides the module `launcher.Manager` to manage the launcher remotely. With it we can remotely launch a browser with custom launch flags. The example to use it is [here](https://github.com/go-rod/rod/blob/master/lib/launcher/rod-manager/main.go).
+For production scraping system, usually, we will separate the scrapers and browsers into different clusters so that they can scale separately. Rod provides the module `launcher.Manager` to manage the launcher remotely. With it we can remotely launch a browser with custom launch flags. The example to use it is [here](https://github.com/go-rod/rod/blob/main/lib/launcher/rod-manager/main.go).
 
 Because it's very hard to install chromium correctly on some linux distributions, Rod provides a docker image to make it consistent cross platforms. Here's an example to use it:
 
 1. Run the rod image `docker run -p 7317:7317 ghcr.io/go-rod/rod`
 
-2. Open another terminal and run code like this [example](https://github.com/go-rod/rod/blob/master/lib/examples/remote-launch/main.go)
+2. Open another terminal and run code like this [example](https://github.com/go-rod/rod/blob/main/lib/examples/remote-launch/main.go)
 
-The image is [tuned](https://github.com/go-rod/rod/blob/master/lib/docker/Dockerfile) for screenshots and fonts among popular natural languages. Each container can launch multiple browsers at the same time.
+The image is [tuned](https://github.com/go-rod/rod/blob/main/lib/docker/Dockerfile) for screenshots and fonts among popular natural languages. Each container can launch multiple browsers at the same time.
 
 ## User mode :id=user-mode
 
@@ -124,8 +124,8 @@ wsURL := launcher.NewUserMode().MustLaunch()
 rod.New().ControlURL(wsURL).MustConnect().NoDefaultDevice()
 ```
 
-Here's a more detailed example: [code example](https://github.com/go-rod/rod/blob/master/lib/examples/use-rod-like-chrome-extension/main.go).
+Here's a more detailed example: [code example](https://github.com/go-rod/rod/blob/main/lib/examples/use-rod-like-chrome-extension/main.go).
 
 ## Low-level API
 
-If you want to control every step of the launch process, such as disable the auto-download and use the system's default browser, check the [example file](https://github.com/go-rod/rod/blob/master/lib/launcher/example_test.go).
+If you want to control every step of the launch process, such as disable the auto-download and use the system's default browser, check the [example file](https://github.com/go-rod/rod/blob/main/lib/launcher/example_test.go).

--- a/i18n/fr-FR/custom-websocket.md
+++ b/i18n/fr-FR/custom-websocket.md
@@ -1,3 +1,3 @@
 # Customize the WebSocket
 
-Useful when you want to proxy the transport layer or tune the performance. Check the example [here](https://github.com/go-rod/rod/blob/master/lib/examples/custom-websocket/main.go).
+Useful when you want to proxy the transport layer or tune the performance. Check the example [here](https://github.com/go-rod/rod/blob/main/lib/examples/custom-websocket/main.go).

--- a/i18n/fr-FR/faq/README.md
+++ b/i18n/fr-FR/faq/README.md
@@ -14,4 +14,4 @@ You can jump to it by searching it from here (keyboard shortcut is `F`):
 
 ![search-symbol-in-doc](search-symbol-in-doc.png)
 
-For experienced developers please check [Terminology](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md#terminology).
+For experienced developers please check [Terminology](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md#terminology).

--- a/i18n/fr-FR/get-started/README.md
+++ b/i18n/fr-FR/get-started/README.md
@@ -43,7 +43,7 @@ Le programme affichera une capture d'écran "a.png" comme celle ci-dessous:
 
 ## Voir ce qui est sous la capuche
 
-Pour les développeurs seniors, vous pouvez sauter tout et lire ce fichier : [lien](https://github.com/go-rod/rod/blob/master/examples_test.go).
+Pour les développeurs seniors, vous pouvez sauter tout et lire ce fichier : [lien](https://github.com/go-rod/rod/blob/main/examples_test.go).
 
 Par défaut, Rod désactivera l'interface utilisateur du navigateur pour maximiser les performances. Mais lors du développement d'une tâche d'automatisation, nous nous soucions plus de la facilité de débogage. Rod provides a lot of helpers to make your debugging experience great.
 

--- a/i18n/fr-FR/join-development.md
+++ b/i18n/fr-FR/join-development.md
@@ -6,4 +6,4 @@ Please read [How To Ask Questions The Smart Way](http://www.catb.org/~esr/faqs/s
 
 We use Github Projects to manage tasks, you can see the priority and progress of the issues [here](https://github.com/orgs/go-rod/projects/1).
 
-If you want to contribute code for this project please read the [Contributor Guide](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)
+If you want to contribute code for this project please read the [Contributor Guide](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

--- a/i18n/fr-FR/network.md
+++ b/i18n/fr-FR/network.md
@@ -96,7 +96,7 @@ page := browser.MustPage("https://test.com/")
 page.HijackRequests()
 ```
 
-For more info check the [hijack tests](https://github.com/go-rod/rod/blob/master/hijack_test.go)
+For more info check the [hijack tests](https://github.com/go-rod/rod/blob/main/hijack_test.go)
 
 ## Throttling
 

--- a/i18n/fr-FR/network/README.md
+++ b/i18n/fr-FR/network/README.md
@@ -96,7 +96,7 @@ page := browser.MustPage("https://test.com/")
 page.HijackRequests()
 ```
 
-For more info check the [hijack tests](https://github.com/go-rod/rod/blob/master/hijack_test.go)
+For more info check the [hijack tests](https://github.com/go-rod/rod/blob/main/hijack_test.go)
 
 ## Throttling
 

--- a/i18n/pt-PT/custom-launch.md
+++ b/i18n/pt-PT/custom-launch.md
@@ -105,15 +105,15 @@ Leia o documento de API para mais informações: [link](https://pkg.go.dev/githu
 
 ## Remotely manage the launcher :id=remotely-manage-the-launcher
 
-Para o sistema de remoção de produção, usualmente, vamos separar os sucatas e navegadores em diferentes clusters para que eles possam escalar separadamente. Rod fornece o módulo `launcher. Manager` para gerenciar o launcher remotamente. Com isso, podemos iniciar um navegador remotamente com bandeiras de inicialização personalizadas. O exemplo a ser usado é [aqui](https://github.com/go-rod/rod/blob/master/lib/launcher/rod-manager/main.go).
+Para o sistema de remoção de produção, usualmente, vamos separar os sucatas e navegadores em diferentes clusters para que eles possam escalar separadamente. Rod fornece o módulo `launcher. Manager` para gerenciar o launcher remotamente. Com isso, podemos iniciar um navegador remotamente com bandeiras de inicialização personalizadas. O exemplo a ser usado é [aqui](https://github.com/go-rod/rod/blob/main/lib/launcher/rod-manager/main.go).
 
 Por ser muito difícil instalar o crómio corretamente em algumas distribuições linux, Rod fornece uma imagem docker para torná-lo uma plataforma cruzada consistente. Aqui está um exemplo para usá-lo:
 
 1. Execute a imagem da vara `docker run -p 7317:7317 ghcr.io/go-rod/rod`
 
-2. Abra outro terminal e execute um código como este [exemplo](https://github.com/go-rod/rod/blob/master/lib/examples/launch-managed/main.go)
+2. Abra outro terminal e execute um código como este [exemplo](https://github.com/go-rod/rod/blob/main/lib/examples/launch-managed/main.go)
 
-A imagem está [ajustada](https://github.com/go-rod/rod/blob/master/lib/docker/Dockerfile) para capturas de tela e fontes entre os idiomas naturais populares. Cada contêiner pode executar vários navegadores ao mesmo tempo.
+A imagem está [ajustada](https://github.com/go-rod/rod/blob/main/lib/docker/Dockerfile) para capturas de tela e fontes entre os idiomas naturais populares. Cada contêiner pode executar vários navegadores ao mesmo tempo.
 
 ## Modo de usuário :id=user-mode
 
@@ -124,8 +124,8 @@ wsURL := launcher. NewUserMode(). MustLaunch()
 rod. New(). ControlURL(wsURL). MustConnect(). NoDefaultDevice()
 ```
 
-Aqui está um exemplo mais detalhado: [exemplo de código](https://github.com/go-rod/rod/blob/master/lib/examples/use-rod-like-chrome-extension/main.go).
+Aqui está um exemplo mais detalhado: [exemplo de código](https://github.com/go-rod/rod/blob/main/lib/examples/use-rod-like-chrome-extension/main.go).
 
 ## API de nível baixo
 
-Se você deseja controlar cada etapa do processo de inicialização, como desativar o download automático e usar o navegador padrão do sistema, verifique o [arquivo de exemplo](https://github.com/go-rod/rod/blob/master/lib/launcher/example_test.go).
+Se você deseja controlar cada etapa do processo de inicialização, como desativar o download automático e usar o navegador padrão do sistema, verifique o [arquivo de exemplo](https://github.com/go-rod/rod/blob/main/lib/launcher/example_test.go).

--- a/i18n/pt-PT/custom-websocket.md
+++ b/i18n/pt-PT/custom-websocket.md
@@ -1,3 +1,3 @@
 # Personalizar o WebSocket
 
-Útil quando você deseja proxy a camada de transporte ou ajustar o desempenho. Check the example [here](https://github.com/go-rod/rod/blob/master/lib/examples/custom-websocket/main.go).
+Útil quando você deseja proxy a camada de transporte ou ajustar o desempenho. Check the example [here](https://github.com/go-rod/rod/blob/main/lib/examples/custom-websocket/main.go).

--- a/i18n/pt-PT/faq/README.md
+++ b/i18n/pt-PT/faq/README.md
@@ -14,4 +14,4 @@ You can jump to it by searching it from here (keyboard shortcut is `F`):
 
 ![search-symbol-in-doc](search-symbol-in-doc.png)
 
-For experienced developers please check [Terminology](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md#terminology).
+For experienced developers please check [Terminology](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md#terminology).

--- a/i18n/pt-PT/get-started/README.md
+++ b/i18n/pt-PT/get-started/README.md
@@ -43,7 +43,7 @@ O programa será criado "a.png" como o exemplo abaixo:
 
 ## Veja o que está sob o capuz
 
-Para desenvolvedores principais, você pode pular todos e ler este arquivo: [link](https://github.com/go-rod/rod/blob/master/examples_test.go).
+Para desenvolvedores principais, você pode pular todos e ler este arquivo: [link](https://github.com/go-rod/rod/blob/main/examples_test.go).
 
 Por padrão, o Rod desativará a interface do navegador para maximizar o desempenho. Mas ao desenvolver uma tarefa de automação, geralmente nos preocupamos mais com a facilidade de depuração. Rod provides a lot of helpers to make your debugging experience great.
 

--- a/i18n/pt-PT/join-development.md
+++ b/i18n/pt-PT/join-development.md
@@ -6,4 +6,4 @@ Leia [Como fazer as perguntas da Smart Way](http://www.catb.org/~esr/faqs/smart-
 
 Nós usamos Projetos do Github para gerenciar tarefas, você pode ver a prioridade e o progresso das issues [aqui](https://github.com/orgs/go-rod/projects/1).
 
-Se você quer contribuir com código para este projeto, por favor leia o [Guia do Colaborador](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)
+Se você quer contribuir com código para este projeto, por favor leia o [Guia do Colaborador](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

--- a/i18n/pt-PT/network.md
+++ b/i18n/pt-PT/network.md
@@ -96,7 +96,7 @@ page := browser. MustPage("https://test.com/")
 page. HijackRequests()
 ```
 
-For more info check the [hijack tests](https://github.com/go-rod/rod/blob/master/hijack_test.go)
+For more info check the [hijack tests](https://github.com/go-rod/rod/blob/main/hijack_test.go)
 
 ## Throttling
 

--- a/i18n/pt-PT/network/README.md
+++ b/i18n/pt-PT/network/README.md
@@ -96,7 +96,7 @@ page := browser. MustPage("https://test.com/")
 page. HijackRequests()
 ```
 
-For more info check the [hijack tests](https://github.com/go-rod/rod/blob/master/hijack_test.go)
+For more info check the [hijack tests](https://github.com/go-rod/rod/blob/main/hijack_test.go)
 
 ## Throttling
 

--- a/i18n/zh-CN/custom-launch.md
+++ b/i18n/zh-CN/custom-launch.md
@@ -105,15 +105,15 @@ func main() {
 
 ## 远程管理启动器 :id=remotely-manage-the-launcher
 
-对于生产环境的爬虫系统，我们通常会把爬虫和浏览器拆分到不同的集群，从而使它们能够独立扩容。 Rod 提供模块 `launcher.Manager` 来远程管理启动器。 通过它我们可以远程启动用自定义启动参数浏览器。 它的用例在 [这里](https://github.com/go-rod/rod/blob/master/lib/launcher/rod-manager/main.go)。
+对于生产环境的爬虫系统，我们通常会把爬虫和浏览器拆分到不同的集群，从而使它们能够独立扩容。 Rod 提供模块 `launcher.Manager` 来远程管理启动器。 通过它我们可以远程启动用自定义启动参数浏览器。 它的用例在 [这里](https://github.com/go-rod/rod/blob/main/lib/launcher/rod-manager/main.go)。
 
 因为很难在某些Linux发行版上正确安装chromium， Rod 提供了一个 docker image 来支持跨平台。 下面是一个用例：
 
 1. 运行 rod 镜像 `docker run -p 7317:7317 ghcr.io/go-rod/rod`
 
-2. 打开另一个终端，并运行类似这个[示例](https://github.com/go-rod/rod/blob/master/lib/examples/launch-managed/main.go)中的代码
+2. 打开另一个终端，并运行类似这个[示例](https://github.com/go-rod/rod/blob/main/lib/examples/launch-managed/main.go)中的代码
 
-它对于常见的自然语言的截图和字体进行过[调优](https://github.com/go-rod/rod/blob/master/lib/docker/Dockerfile)。 每个容器可以同时启动多个浏览器。
+它对于常见的自然语言的截图和字体进行过[调优](https://github.com/go-rod/rod/blob/main/lib/docker/Dockerfile)。 每个容器可以同时启动多个浏览器。
 
 ## 用户模式 :id=user-mode
 
@@ -124,8 +124,8 @@ wsURL := launcher.NewUserMode().MustLaunch()
 rod.New().ControlURL(wsURL).MustConnect().NoDefaultDevice()
 ```
 
-这里是一个更详细的示例： [代码示例](https://github.com/go-rod/rod/blob/master/lib/examples/use-rod-like-chrome-extension/main.go)。
+这里是一个更详细的示例： [代码示例](https://github.com/go-rod/rod/blob/main/lib/examples/use-rod-like-chrome-extension/main.go)。
 
 ## 底层 API
 
-如果你想要控制启动过程中的每个步骤，比如说禁用自动下载、使用系统默认浏览器，见此[示例文件](https://github.com/go-rod/rod/blob/master/lib/launcher/example_test.go)。
+如果你想要控制启动过程中的每个步骤，比如说禁用自动下载、使用系统默认浏览器，见此[示例文件](https://github.com/go-rod/rod/blob/main/lib/launcher/example_test.go)。

--- a/i18n/zh-CN/custom-websocket.md
+++ b/i18n/zh-CN/custom-websocket.md
@@ -1,3 +1,3 @@
 # 自定义 WebSocket
 
-如果你想要代理传输层或调优性能的话这会很有用。 请看这里的[代码](https://github.com/go-rod/rod/blob/master/lib/examples/custom-websocket/main.go)。
+如果你想要代理传输层或调优性能的话这会很有用。 请看这里的[代码](https://github.com/go-rod/rod/blob/main/lib/examples/custom-websocket/main.go)。

--- a/i18n/zh-CN/faq/README.md
+++ b/i18n/zh-CN/faq/README.md
@@ -14,4 +14,4 @@
 
 ![search-symbol-in-doc](search-symbol-in-doc.png)
 
-对于经验丰富的开发人员，请查看 [Terminology](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md#terminology)。
+对于经验丰富的开发人员，请查看 [Terminology](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md#terminology)。

--- a/i18n/zh-CN/get-started/README.md
+++ b/i18n/zh-CN/get-started/README.md
@@ -43,7 +43,7 @@ go run .
 
 ## 了解发生了什么
 
-对于有经验的开发者，可以跳过这里的所有内容、阅读[这个文件](https://github.com/go-rod/rod/blob/master/examples_test.go)。
+对于有经验的开发者，可以跳过这里的所有内容、阅读[这个文件](https://github.com/go-rod/rod/blob/main/examples_test.go)。
 
 默认情况下，Rod 会禁用浏览器的 UI 来最大化性能。 但开发自动化任务时我们通常更加关心调试的难易程度。 Rod 提供了很多用于提升调试体验帮助函数。
 

--- a/i18n/zh-CN/join-development.md
+++ b/i18n/zh-CN/join-development.md
@@ -6,4 +6,4 @@
 
 我们使用 Github Projects 来管理任务，你可以 [在这里](https://github.com/orgs/go-rod/projects/1) 看到 issue 的优先级和进度。
 
-如果你想为这个项目贡献代码，请阅读 [贡献者指南](https://github.com/go-rod/rod/blob/master/.github/CONTRIBUTING.md)
+如果你想为这个项目贡献代码，请阅读 [贡献者指南](https://github.com/go-rod/rod/blob/main/.github/CONTRIBUTING.md)

--- a/i18n/zh-CN/network.md
+++ b/i18n/zh-CN/network.md
@@ -96,7 +96,7 @@ page := browser.MustPage("https://test.com/")
 page.HijackRequests()
 ```
 
-更多信息，见[劫持相关的单元测试](https://github.com/go-rod/rod/blob/master/hijack_test.go)
+更多信息，见[劫持相关的单元测试](https://github.com/go-rod/rod/blob/main/hijack_test.go)
 
 ## 节流
 

--- a/i18n/zh-CN/network/README.md
+++ b/i18n/zh-CN/network/README.md
@@ -96,7 +96,7 @@ page := browser.MustPage("https://test.com/")
 page.HijackRequests()
 ```
 
-更多信息，见[劫持相关的单元测试](https://github.com/go-rod/rod/blob/master/hijack_test.go)
+更多信息，见[劫持相关的单元测试](https://github.com/go-rod/rod/blob/main/hijack_test.go)
 
 ## 节流
 


### PR DESCRIPTION
rod 将默认 branch 从 master 换到了 main，但文档中的链接都没换。所以我把项目中所有的 "go-rod/rod/blob/master/" 替换成了 "go-rod/rod/blob/main/"。我也在本地随便试了下，链接能打开。

There was no change in doc site since rod's default branch changed from "master" to "main". So, I replaced all "go-rod/rod/blob/master/" to "go-rod/rod/blob/main/". Also, I tried it in local, the new links are working.